### PR TITLE
r オプションを追加

### DIFF
--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -7,7 +7,7 @@ MAX_COLUMN = 3
 COLUMN_WIDTH = 15
 
 def main
-  option = ARGV.getopts('a')
+  option = ARGV.getopts('r')
   directory = ARGV[0] || Dir.getwd
   files = sort_files(directory, option)
   rows = create_rows(files)
@@ -15,8 +15,8 @@ def main
 end
 
 def sort_files(directory, option)
-  a_option = option['a'] ? File::FNM_DOTMATCH : 0
-  Dir.glob('*', a_option, base: directory)
+  files = Dir.glob('*', base: directory)
+  option['r'] ? files.reverse : files
 end
 
 def create_rows(files)


### PR DESCRIPTION
## やったこと

`r` オプションの追加

## できるようになること（ユーザ目線）

`r` オプションの有無で表示ファイルの並びを昇順と降順を切り替えることができる

## できなくなること（ユーザ目線）

`a`オプションの記述を削除した為、`a`オプションが機能しなくなる

## 動作確認

* サンプルディレクトリ`sample_dir` 内に`sample_xx.md`の形でテストファイルを作成し、ファイル表示をオプションの有無で昇順、降順の表示を確認しました
* `rubocop` を使って修正点の確認と修正を行いました
