### PR TITLE
l オプションを追加

### DIFF
--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -29,23 +29,23 @@ PERMISSION = {
 
 def main
   option = ARGV.getopts('l')
-  path = ARGV[0] || Dir.getwd
-  files = directory?(path) ? sort_files(path) : [] << path
-  option['l'] ? output_file_detail(files, path) : output_file_names(files)
+  argument_path = ARGV[0] || Dir.getwd
+  files = directory?(argument_path) ? sort_files(argument_path) : [] << argument_path
+  option['l'] ? output_file_detail(files, argument_path) : output_file_names(files)
 end
 
-def directory?(path)
-  File.stat(path).directory?
+def directory?(argument_path)
+  File.lstat(argument_path).directory?
 end
 
-def sort_files(path)
-  Dir.glob('*', base: path)
+def sort_files(argument_path)
+  Dir.glob('*', base: argument_path)
 end
 
-def output_file_detail(files, path)
-  output_total(files) if files.size > 1
-  files.map do |i|
-    file = directory?(path) ? File.lstat(File.join(path, i)) : File.lstat(i)
+def output_file_detail(files, argument_path)
+  output_total_blocks(files, argument_path) if files.size > 1
+  files.each do |i|
+    file = directory?(argument_path) ? File.lstat(File.join(argument_path, i)) : File.lstat(i)
     type = FILE_TYPE[file.ftype.to_sym]
     permission = convert_to_permission(file)
     nlink = file.nlink.to_s.rjust(2)
@@ -58,8 +58,11 @@ def output_file_detail(files, path)
   end
 end
 
-def output_total(_files)
-  puts 'total 0000'
+def output_total_blocks(files, argument_path)
+  total_blocks = files.map do |i|
+    File.lstat(File.join(argument_path, i)).blocks
+  end.inject(:+)
+  puts "total #{total_blocks}"
 end
 
 def convert_to_permission(file)

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -26,6 +26,16 @@ PERMISSION = {
   '6': 'rw-',
   '7': 'rwx'
 }.freeze
+DIGIT_TO_INDEX = {
+  '1': -1,
+  '4': 2,
+  '2': 5
+}.freeze
+DIGIT_TO_PERMISSION = {
+  '1': 't',
+  '4': 's',
+  '2': 's'
+}.freeze
 
 def main
   option = ARGV.getopts('l')
@@ -75,14 +85,9 @@ def convert_to_permission(file)
 end
 
 def add_special_permission(permission, special_permission_digit)
-  case special_permission_digit
-  when '1'
-    permission[-1] = permission[-1] == '-' ? 'T' : 't'
-  when '4'
-    permission[2] = permission[2] == '-' ? 'S' : 's'
-  when '2'
-    permission[5] = permission[5] == '-' ? 'S' : 's'
-  end
+  update_index = DIGIT_TO_INDEX[special_permission_digit.to_sym]
+  special_permission = DIGIT_TO_PERMISSION[special_permission_digit.to_sym]
+  permission[update_index] = permission[update_index] == '-' ? special_permission.upcase : special_permission
   permission
 end
 

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -30,7 +30,7 @@ PERMISSION = {
 def main
   option = ARGV.getopts('l')
   argument_path = ARGV[0] || Dir.getwd
-  files = directory?(argument_path) ? sort_files(argument_path) : [] << argument_path
+  files = directory?(argument_path) ? select_files(argument_path) : [argument_path]
   option['l'] ? output_file_detail(files, argument_path) : output_file_names(files)
 end
 
@@ -38,7 +38,7 @@ def directory?(argument_path)
   File.lstat(argument_path).directory?
 end
 
-def sort_files(argument_path)
+def select_files(argument_path)
   Dir.glob('*', base: argument_path)
 end
 
@@ -61,21 +61,21 @@ end
 def output_total_blocks(files, argument_path)
   total_blocks = files.map do |i|
     File.lstat(File.join(argument_path, i)).blocks
-  end.inject(:+)
+  end.sum
   puts "total #{total_blocks}"
 end
 
 def convert_to_permission(file)
-  permission_numbers = file.mode.to_s(8)[-3, 3].split('')
-  permission = permission_numbers.map do |i|
+  permission_digits = file.mode.to_s(8)[-3, 3].split('')
+  permission = permission_digits.map do |i|
     PERMISSION[i.to_sym]
   end.join
-  special_permission_number = file.mode.to_s(8)[-4]
-  special_permission_number == '0' ? permission : add_special_permission(permission, special_permission_number)
+  special_permission_digit = file.mode.to_s(8)[-4]
+  special_permission_digit == '0' ? permission : add_special_permission(permission, special_permission_digit)
 end
 
-def add_special_permission(permission, special_permission_number)
-  case special_permission_number
+def add_special_permission(permission, special_permission_digit)
+  case special_permission_digit
   when '1'
     permission[-1] = permission[-1] == '-' ? 'T' : 't'
   when '4'

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -2,24 +2,83 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'etc'
 
 MAX_COLUMN = 3
 COLUMN_WIDTH = 15
+FILE_TYPE = {
+  'file': '-',
+  'directory': 'd',
+  'caracterSpecial': 'c',
+  'blockSpecial': 'b',
+  'fifo': 'p',
+  'link': 'l',
+  'socket': 's',
+  'unknown': ''
+}.freeze
+PERMISSION = {
+  '0': '---',
+  '1': '--x',
+  '2': '-w-',
+  '3': '-wx',
+  '4': 'r--',
+  '5': 'r-x',
+  '6': 'rw-',
+  '7': 'rwx'
+}.freeze
 
 def main
-  option = ARGV.getopts('r')
-  directory = ARGV[0] || Dir.getwd
-  files = sort_files(directory, option)
-  rows = create_rows(files)
-  list_files(rows)
+  option = ARGV.getopts('l')
+  path = ARGV[0] || Dir.getwd
+  files = directory?(path) ? sort_files(path) : [] << path
+  option['l'] ? output_file_detail(files, path) : output_file_names(files)
 end
 
-def sort_files(directory, option)
-  files = Dir.glob('*', base: directory)
-  option['r'] ? files.reverse : files
+def directory?(path)
+  File.stat(path).directory?
 end
 
-def create_rows(files)
+def sort_files(path)
+  Dir.glob('*', base: path)
+end
+
+def add_special_permission(permission, special_permission_number)
+  case special_permission_number
+  when '1'
+    permission[-1] = permission[-1] == '-' ? 'T' : 't'
+  when '4'
+    permission[2] = permission[2] == '-' ? 'S' : 's'
+  when '2'
+    permission[5] = permission[5] == '-' ? 'S' : 's'
+  end
+  permission
+end
+
+def convert_to_permission(file)
+  permission_numbers = file.mode.to_s(8)[-3, 3].split('')
+  permission = permission_numbers.map do |i|
+    PERMISSION[i.to_sym]
+  end.join
+  special_permission_number = file.mode.to_s(8)[-4]
+  special_permission_number == '0' ? permission : add_special_permission(permission, special_permission_number)
+end
+
+def output_file_detail(files, path)
+  files.map do |i|
+    file = directory?(path) ? File.lstat(File.join(path, i)) : File.lstat(i)
+    type = FILE_TYPE[file.ftype.to_sym]
+    permission = convert_to_permission(file)
+    nlink = file.nlink.to_s.rjust(2)
+    user = Etc.getpwuid(file.uid).name
+    group = Etc.getgrgid(file.gid).name
+    size = file.size.to_s.rjust(4)
+    date = "#{file.mtime.month.to_s.rjust(2)} #{file.mtime.day.to_s.rjust(2)}"
+    time = "#{file.mtime.strftime('%H')}:#{file.mtime.strftime('%M')}"
+    puts "#{type}#{permission} #{nlink} #{user}  #{group} #{size} #{date} #{time} #{i}"
+  end
+end
+
+def output_file_names(files)
   rows = []
   max_row = (files.count / MAX_COLUMN.to_f).ceil
   max_row.times do |t|
@@ -30,10 +89,6 @@ def create_rows(files)
     end
     rows << row_items
   end
-  rows
-end
-
-def list_files(rows)
   rows.each do |i|
     puts i.join('')
   end

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -42,28 +42,8 @@ def sort_files(path)
   Dir.glob('*', base: path)
 end
 
-def add_special_permission(permission, special_permission_number)
-  case special_permission_number
-  when '1'
-    permission[-1] = permission[-1] == '-' ? 'T' : 't'
-  when '4'
-    permission[2] = permission[2] == '-' ? 'S' : 's'
-  when '2'
-    permission[5] = permission[5] == '-' ? 'S' : 's'
-  end
-  permission
-end
-
-def convert_to_permission(file)
-  permission_numbers = file.mode.to_s(8)[-3, 3].split('')
-  permission = permission_numbers.map do |i|
-    PERMISSION[i.to_sym]
-  end.join
-  special_permission_number = file.mode.to_s(8)[-4]
-  special_permission_number == '0' ? permission : add_special_permission(permission, special_permission_number)
-end
-
 def output_file_detail(files, path)
+  output_total(files) if files.size > 1
   files.map do |i|
     file = directory?(path) ? File.lstat(File.join(path, i)) : File.lstat(i)
     type = FILE_TYPE[file.ftype.to_sym]
@@ -76,6 +56,31 @@ def output_file_detail(files, path)
     time = "#{file.mtime.strftime('%H')}:#{file.mtime.strftime('%M')}"
     puts "#{type}#{permission} #{nlink} #{user}  #{group} #{size} #{date} #{time} #{i}"
   end
+end
+
+def output_total(_files)
+  puts 'total 0000'
+end
+
+def convert_to_permission(file)
+  permission_numbers = file.mode.to_s(8)[-3, 3].split('')
+  permission = permission_numbers.map do |i|
+    PERMISSION[i.to_sym]
+  end.join
+  special_permission_number = file.mode.to_s(8)[-4]
+  special_permission_number == '0' ? permission : add_special_permission(permission, special_permission_number)
+end
+
+def add_special_permission(permission, special_permission_number)
+  case special_permission_number
+  when '1'
+    permission[-1] = permission[-1] == '-' ? 'T' : 't'
+  when '4'
+    permission[2] = permission[2] == '-' ? 'S' : 's'
+  when '2'
+    permission[5] = permission[5] == '-' ? 'S' : 's'
+  end
+  permission
 end
 
 def output_file_names(files)


### PR DESCRIPTION
# やったこと

`l` オプションの追加

# やらないこと

`a`、`r` オプションの実装

# できるようになること（ユーザ目線）

`l` オプションの有無でファイル名の一覧表示とファイル詳細の一覧表示を切り替えることができる

# できなくなること（ユーザ目線）

`r` オプションの記述を削除したので`r` オプションが機能しなくなる

# 動作確認

* プログラムのルートディレクトリにサンプルディレクトリ`sample_dir_1/`内に下記のファイルを作成し、`l` オプション無しの動作を確認しました
  * `sample_xx.md`: 表示順を確認
  * `.dotfile`: `.`から始まるファイルの非表示を確認
  * `child_dir/`: 子ディレクトリの表示
  * `child_dir/child.md`: 小ディレクトリ内のファイルの表示を確認
* プログラムのルートディレクトリにサンプルディレクトリ`sample_dir_2/` 内に下記のファイルを作成し、`l` オプション有りの動作を確認しました
  * `sample_directory`: ディレクトリを指す`d` の表示を確認
  * `sample_file`: ファイルを指す`-` の表示を確認
  * `sample_link`: シンボリックを指す`l` の表示を確認
  * `444`: パーミッション`r--r--r--` の表示を確認
  * `666`: パーミッション`rw-rw-rw-` の表示を確認
  * `777`: パーミッション`rwxrwxrwx` の表示を確認
  * `Sticky_666/`: 一般ユーザに実行権限`x` が無い場合のスティッキービットが付与されたパーミッション`rw-rw-rwT` の表示を確認
  * `Sticky_777/`: 一般ユーザに実行権限`x` が有る場合のスティッキービットが付与されたパーミッション`rwxrwxrwt` の表示を確認
  * `SUID_666`: 所有ユーザに実行権限`x` が無い場合のSUID が付与されたパーミッション`rwSrw-rw-` の表示を確認
  * `SUID_777`: 所有ユーザに実行権限`x` が有る場合のSUID が付与されたパーミッション`rwsrwxrwx` の表示を確認
  * `SGID_666`: 所有グループに実行権限`x` が無い場合のSGID が付与されたパーミッション`rw-rwSrw-` の表示を確認
  * `SUID_777`: 所有グループに実行権限`x` が有る場合のSGID が付与されたパーミッション`rwxrwsrwx` の表示を確認
* rubocop を使って修正点の確認と修正を行いました