### PR TITLE
a、r、lオプションを追加

### DIFF
--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -39,25 +39,25 @@ DIGIT_TO_PERMISSION = {
 
 def main
   options = ARGV.getopts('arl')
-  argument_path = ARGV[0] || Dir.getwd
-  files = select_files(argument_path, options)
-  options['l'] ? output_file_detail(files, argument_path) : output_file_names(files)
+  path = ARGV[0] || Dir.getwd
+  files = select_files(path, options)
+  options['l'] ? output_file_detail(files, path) : output_file_names(files)
 end
 
-def select_files(argument_path, options)
+def select_files(path, options)
   selected_files =
-    if File.lstat(argument_path).directory?
-      Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0, base: argument_path)
+    if File.lstat(path).directory?
+      Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0, base: path)
     else
-      [argument_path]
+      [path]
     end
   options['r'] ? selected_files.reverse : selected_files
 end
 
-def output_file_detail(files, argument_path)
-  output_total_blocks(files, argument_path) if files.size > 1
+def output_file_detail(files, path)
+  output_total_blocks(files, path) if files.size > 1
   files.each do |i|
-    file = File.lstat(argument_path).directory? ? File.lstat(File.join(argument_path, i)) : File.lstat(i)
+    file = File.lstat(path).directory? ? File.lstat(File.join(path, i)) : File.lstat(i)
     type = FILE_TYPE[file.ftype.to_sym]
     permission = convert_to_permission(file)
     nlink = file.nlink.to_s.rjust(2)
@@ -70,9 +70,9 @@ def output_file_detail(files, argument_path)
   end
 end
 
-def output_total_blocks(files, argument_path)
+def output_total_blocks(files, path)
   total_blocks = files.map do |i|
-    File.lstat(File.join(argument_path, i)).blocks
+    File.lstat(File.join(path, i)).blocks
   end.sum
   puts "total #{total_blocks}"
 end

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -46,7 +46,7 @@ end
 
 def select_files(argument_path, options)
   selected_files =
-    if directory?(argument_path)
+    if File.lstat(argument_path).directory?
       Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0, base: argument_path)
     else
       [argument_path]
@@ -54,14 +54,10 @@ def select_files(argument_path, options)
   options['r'] ? selected_files.reverse : selected_files
 end
 
-def directory?(argument_path)
-  File.lstat(argument_path).directory?
-end
-
 def output_file_detail(files, argument_path)
   output_total_blocks(files, argument_path) if files.size > 1
   files.each do |i|
-    file = directory?(argument_path) ? File.lstat(File.join(argument_path, i)) : File.lstat(i)
+    file = File.lstat(argument_path).directory? ? File.lstat(File.join(argument_path, i)) : File.lstat(i)
     type = FILE_TYPE[file.ftype.to_sym]
     permission = convert_to_permission(file)
     nlink = file.nlink.to_s.rjust(2)

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -40,18 +40,16 @@ DIGIT_TO_PERMISSION = {
 def main
   options = ARGV.getopts('arl')
   path = ARGV[0] || Dir.getwd
-  files = select_files(path, options)
+  files = select_files(path, all: options['a'], reverse: options['r'])
   options['l'] ? output_file_detail(files, path) : output_file_names(files)
 end
 
-def select_files(path, options)
-  selected_files =
-    if File.lstat(path).directory?
-      Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0, base: path)
-    else
-      [path]
-    end
-  options['r'] ? selected_files.reverse : selected_files
+def select_files(path, all: false, reverse: false)
+  return [path] unless File.lstat(path).directory?
+
+  select_option = all ? File::FNM_DOTMATCH : 0
+  selected_files = Dir.glob('*', select_option, base: path)
+  reverse ? selected_files.reverse : selected_files
 end
 
 def output_file_detail(files, path)

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -40,16 +40,20 @@ DIGIT_TO_PERMISSION = {
 def main
   options = ARGV.getopts('arl')
   argument_path = ARGV[0] || Dir.getwd
-  files = directory?(argument_path) ? select_files(argument_path) : [argument_path]
+  files = select_files(argument_path, options)
   options['l'] ? output_file_detail(files, argument_path) : output_file_names(files)
+end
+
+def select_files(argument_path, options)
+  if directory?(argument_path)
+    Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0, base: argument_path)
+  else
+    [argument_path]
+  end
 end
 
 def directory?(argument_path)
   File.lstat(argument_path).directory?
-end
-
-def select_files(argument_path)
-  Dir.glob('*', base: argument_path)
 end
 
 def output_file_detail(files, argument_path)

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -45,11 +45,13 @@ def main
 end
 
 def select_files(argument_path, options)
-  if directory?(argument_path)
-    Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0, base: argument_path)
-  else
-    [argument_path]
-  end
+  selected_files =
+    if directory?(argument_path)
+      Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0, base: argument_path)
+    else
+      [argument_path]
+    end
+  options['r'] ? selected_files.reverse : selected_files
 end
 
 def directory?(argument_path)

--- a/05.ls/list.rb
+++ b/05.ls/list.rb
@@ -38,10 +38,10 @@ DIGIT_TO_PERMISSION = {
 }.freeze
 
 def main
-  option = ARGV.getopts('l')
+  options = ARGV.getopts('arl')
   argument_path = ARGV[0] || Dir.getwd
   files = directory?(argument_path) ? select_files(argument_path) : [argument_path]
-  option['l'] ? output_file_detail(files, argument_path) : output_file_names(files)
+  options['l'] ? output_file_detail(files, argument_path) : output_file_names(files)
 end
 
 def directory?(argument_path)


### PR DESCRIPTION
## やったこと

`a`、`r`、`l` オプションを追加

## やらないこと

以下の歓迎要件については未実装

* 半角英数字以外のファイル名（ひらがなや漢字など）を持つファイルがあっても表示が崩れない
* mac拡張属性（@マークで表示される）に対応する

## できるようになること

* `a` オプションを追加時に`.` から始まるファイルを表示できる
* `r` オプションを追加時に表示順を反転できる
* `l` オプションを追加時にファイルの詳細を表示できる
* 上記3つのオプションを組み合わせて表示することができる
* 各オプションの指定順に関係無くオプションが動作する

## 動作確認

* プログラムのルートディレクトリにサンプルディレクトリ`sample_dir_1/`内に下記のファイルを作成し、ファイル毎に下記の動作を確認しました
  * `sample_xx.md`: `r` オプション追加時の表示順を確認
  * `.dotfile`: `.`から始まるファイルの`a` オプション追加時の表示/非表示を確認
  * `child_dir/`: 子ディレクトリの表示の確認
  * `child_dir/child.md`: 小ディレクトリ内のファイルの表示を確認
* プログラムのルートディレクトリにサンプルディレクトリ`sample_dir_2/` 内に下記のファイルを作成し、ファイル毎に`l` オプション有りの動作を確認しました
  * `sample_directory`: ディレクトリを指す`d` の表示を確認
  * `sample_file`: ファイルを指す`-` の表示を確認
  * `sample_link`: シンボリックを指す`l` の表示を確認
  * `444`: パーミッション`r--r--r--` の表示を確認
  * `666`: パーミッション`rw-rw-rw-` の表示を確認
  * `777`: パーミッション`rwxrwxrwx` の表示を確認
  * `Sticky_666/`: 一般ユーザに実行権限`x` が無い場合のスティッキービットが付与されたパーミッション`rw-rw-rwT` の表示を確認
  * `Sticky_777/`: 一般ユーザに実行権限`x` が有る場合のスティッキービットが付与されたパーミッション`rwxrwxrwt` の表示を確認
  * `SUID_666`: 所有ユーザに実行権限`x` が無い場合のSUID が付与されたパーミッション`rwSrw-rw-` の表示を確認
  * `SUID_777`: 所有ユーザに実行権限`x` が有る場合のSUID が付与されたパーミッション`rwsrwxrwx` の表示を確認
  * `SGID_666`: 所有グループに実行権限`x` が無い場合のSGID が付与されたパーミッション`rw-rwSrw-` の表示を確認
  * `SUID_777`: 所有グループに実行権限`x` が有る場合のSGID が付与されたパーミッション`rwxrwsrwx` の表示を確認
* rubocop を使って修正点の確認と修正を行いました
